### PR TITLE
Add support for preview frame time code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # tool caches
 .mypy_cache/
 __pycache__/
+
+# Mac OS folder file
+.DS_Store

--- a/appstore_tools/actions/publish.py
+++ b/appstore_tools/actions/publish.py
@@ -123,6 +123,16 @@ def publish_screenshot(
     _, file_name = os.path.split(screenshot_path)
     file_stat = os.stat(screenshot_path)
 
+    _, screenshot_ext = os.path.splitext(file_name)
+
+    if screenshot_ext.lower() not in [".jpg", ".jpeg", ".png", ".tif", ".tiff", ".bmp"]:
+        print_media_status(
+            file_name,
+            colorama.Fore.RED,
+            f"{screenshot_ext.lower()} is not a valid screenshot file extension, skipping",
+        )
+        return
+
     # Create
     print_media_status(
         file_name,

--- a/appstore_tools/actions/publish.py
+++ b/appstore_tools/actions/publish.py
@@ -272,6 +272,17 @@ def publish_preview(
     preview_folder_path, file_name = os.path.split(preview_path)
     file_stat = os.stat(preview_path)
 
+    preview_name, preview_ext = os.path.splitext(file_name)
+
+    if preview_ext.lower() not in [".avi", ".mp4", ".mov"]:
+        if preview_ext.lower() != ".txt":
+            print_media_status(
+                file_name,
+                colorama.Fore.RED,
+                f"{preview_ext.lower()} is not a valid video file extension, skipping",
+            )
+        return
+
     # Create
     print_media_status(
         file_name,
@@ -295,13 +306,13 @@ def publish_preview(
     )
 
     preview_frame_time_code_filepath = os.path.join(
-        preview_folder_path, os.path.splitext(file_name)[0] + ".txt"
+        preview_folder_path, preview_name + ".txt"
     )
 
     preview_frame_time_code = "00:00:00:01"
     if os.path.exists(preview_frame_time_code_filepath):
         with open(
-            "preview_frame_time_code_filepath", "r"
+            preview_frame_time_code_filepath, "r"
         ) as preview_frame_time_code_file:
             preview_frame_time_code = preview_frame_time_code_file.read()
 

--- a/appstore_tools/actions/publish.py
+++ b/appstore_tools/actions/publish.py
@@ -269,7 +269,7 @@ def publish_preview(
     if not os.path.isfile(preview_path):
         raise FileNotFoundError(f"Preview path does not exist: {preview_path}")
 
-    _, file_name = os.path.split(preview_path)
+    preview_folder_path, file_name = os.path.split(preview_path)
     file_stat = os.stat(preview_path)
 
     # Create
@@ -293,12 +293,43 @@ def publish_preview(
         colorama.Fore.CYAN,
         "commiting upload",
     )
+
+    preview_frame_time_code_filepath = os.path.join(
+        preview_folder_path, os.path.splitext(file_name)[0] + ".txt"
+    )
+
+    preview_frame_time_code = "00:00:00:01"
+    if os.path.exists(preview_frame_time_code_filepath):
+        with open(
+            "preview_frame_time_code_filepath", "r"
+        ) as preview_frame_time_code_file:
+            preview_frame_time_code = preview_frame_time_code_file.read()
+
     preview = appstore.update_preview(
         preview_id=preview["id"],
         uploaded=True,
-        sourceFileChecksum=checksum,
+        source_file_checksum=checksum,
         access_token=access_token,
+        preview_frame_time_code=preview_frame_time_code,
     )
+
+    if hasattr(preview, "status_code") and preview.status_code == 204:
+        print_media_status(
+            file_name,
+            colorama.Fore.RED,
+            "invalid app preview, asset deleted",
+        )
+    else:
+        print_media_status(
+            file_name,
+            colorama.Fore.CYAN,
+            "valid app preview",
+        )
+        print_media_status(
+            file_name,
+            colorama.Fore.CYAN,
+            f"poster frame time code set at {preview_frame_time_code}",
+        )
 
 
 def publish_previews(

--- a/appstore_tools/appstore/api.py
+++ b/appstore_tools/appstore/api.py
@@ -639,16 +639,11 @@ def create_preview(
 
 
 def fetch_status(preview_id: str, access_token: AccessToken):
-    return (
-        fetch(
-            method=FetchMethod.GET,
-            path=f"/appPreviews/{preview_id}",
-            access_token=access_token,
-        )["data"]
-        .get("attributes", {})
-        .get("assetDeliveryState", {})
-        .get("state")
-    )
+    return fetch(
+        method=FetchMethod.GET,
+        path=f"/appPreviews/{preview_id}",
+        access_token=access_token,
+    )["data"]["attributes"]["assetDeliveryState"]["state"]
 
 
 def wait_for_uploaded_status(preview_id: str, access_token: AccessToken):


### PR DESCRIPTION
This PR introduces two features:

(1) validation of the uploaded app previews and removal of "FAILED" uploaded assets (thus preventing things such as those describe in #7 to happen in the frontend)
(2) setting of the preview time code to either: `00:00:00:01` or the value of the `<preview_name_without_extension>.txt`. Note that this is an opinionated choice, as the app store by default uses the value at `00:00:05:01` which to me is quite non-sensical (#4) 