### PR TITLE
Preview attributes

### DIFF
--- a/appstore_tools/actions/download.py
+++ b/appstore_tools/actions/download.py
@@ -1,10 +1,11 @@
 import colorama
 import os
 from appstore_tools import appstore
-from appstore_tools.print_util import print_clr, clr
+from appstore_tools.print_util import print_clr, clr, json_file
 from appstore_tools.tqdm_util import tqdm_with_redirect
 from appstore_tools.appstore.auth import AccessToken
 from .util import (
+    get_attributes_file_path,
     write_txt_file,
     write_binary_file,
     fetch_screenshot,
@@ -167,6 +168,16 @@ def download_version(
                         write_binary_file(
                             path=file_path,
                             content=response.content,
+                        )
+                        write_txt_file(
+                            path=get_attributes_file_path(file_path),
+                            content=json_file(
+                                {
+                                    "previewFrameTimeCode": preview["attributes"][
+                                        "previewFrameTimeCode"
+                                    ]
+                                }
+                            ),
                         )
                     else:
                         print_media_status(

--- a/appstore_tools/actions/list.py
+++ b/appstore_tools/actions/list.py
@@ -312,7 +312,7 @@ def list_previews(
                     json_term(
                         {
                             "previewType": preview_type,
-                            "screenshots": previews,
+                            "previews": previews,
                         }
                     )
                 )

--- a/appstore_tools/actions/util.py
+++ b/appstore_tools/actions/util.py
@@ -6,6 +6,10 @@ from enum import Enum, auto
 from appstore_tools.print_util import print_clr, clr, json_term
 
 
+def get_attributes_file_path(media_file_path: str) -> str:
+    return media_file_path + ".json"
+
+
 def fetch_screenshot(screenshot: dict):
     """Fetches screenshot data. Retuns None if screenshot has no asset."""
     attr = screenshot["attributes"]

--- a/appstore_tools/appstore/api.py
+++ b/appstore_tools/appstore/api.py
@@ -611,6 +611,8 @@ def create_preview(
     file_name: str,
     file_size: int,
     access_token: AccessToken,
+    mime_type: str = "",
+    preview_frame_time_code: str = "",
 ):
     """Create a preview asset reservation in the specified preview set.
     Use the upload operations in the response to upload the file parts."""
@@ -622,7 +624,16 @@ def create_preview(
         access_token=access_token,
         data={
             "data": {
-                "attributes": {"fileName": file_name, "fileSize": file_size},
+                "attributes": {
+                    "fileName": file_name,
+                    "fileSize": file_size,
+                    **({"mimeType": mime_type} if mime_type else {}),
+                    **(
+                        {"previewFrameTimeCode": preview_frame_time_code}
+                        if preview_frame_time_code
+                        else {}
+                    ),
+                },
                 "relationships": {
                     "appPreviewSet": {
                         "data": {
@@ -639,9 +650,10 @@ def create_preview(
 
 def update_preview(
     preview_id: str,
-    uploaded: bool,
-    sourceFileChecksum: str,
     access_token: AccessToken,
+    uploaded: bool = None,
+    source_file_checksum: str = "",
+    preview_frame_time_code: str = "",
 ):
     """Update the preview to commit it after a successful upload."""
 
@@ -654,8 +666,17 @@ def update_preview(
             "data": {
                 "id": preview_id,
                 "attributes": {
-                    "uploaded": uploaded,
-                    "sourceFileChecksum": sourceFileChecksum,
+                    **({"uploaded": uploaded} if uploaded is not None else {}),
+                    **(
+                        {"sourceFileChecksum": source_file_checksum}
+                        if source_file_checksum
+                        else {}
+                    ),
+                    **(
+                        {"previewFrameTimeCode": preview_frame_time_code}
+                        if preview_frame_time_code
+                        else {}
+                    ),
                 },
                 "type": "appPreviews",
             }

--- a/appstore_tools/console.py
+++ b/appstore_tools/console.py
@@ -451,6 +451,11 @@ def run():
     add_asset_ignore_argument(publish_group)
     add_platform_argument(publish_group)
     publish_group.add_argument(
+        "--media-completion-timeout",
+        default=300,
+        help="The number of seconds to wait for media completion when attempting to update attributes on newly uploaded assets.",
+    )
+    publish_group.add_argument(
         "--version-string",
         help="Update the version string in the app store version.",
     )

--- a/appstore_tools/console_actions.py
+++ b/appstore_tools/console_actions.py
@@ -143,6 +143,7 @@ def publish(args):
         platform=args.platform,
         version_string=args.version_string or args.created_version_string,
         update_version_string=args.version_string is not None,
+        media_completion_timeout_secs=args.media_completion_timeout,
         asset_ignore=args.asset_ignore,
         allow_create_version=not args.no_create_version,
         allow_create_locale=not args.no_create_locale,

--- a/appstore_tools/console_actions.py
+++ b/appstore_tools/console_actions.py
@@ -105,6 +105,7 @@ def list_previews(args):
         platforms=platforms,
         states=states,
         version_limit=args.version_limit,
+        verbosity=args.verbosity,
     )
 
 

--- a/appstore_tools/print_util.py
+++ b/appstore_tools/print_util.py
@@ -6,7 +6,12 @@ import colorama
 from typing import Any
 
 
-def json_term(obj: Any):
+def json_file(obj: Any) -> str:
+    """Stringifies the object with json formatting for file output."""
+    return json.dumps(obj, indent=2)
+
+
+def json_term(obj: Any) -> str:
     """Stringifies the object with json syntax highlighting for the terminal."""
     obj_formatted = json.dumps(obj, indent=2)
     return pygments.highlight(


### PR DESCRIPTION
- add ability to set attributes for `preview` media files using an accompanying `json` file.
- added `--media-completion-timeout` console arg to specify a timeout period when waiting to set attributes on newly uploaded media assets
- added support for the optional parameters to the preview `create` and `update` APIs.